### PR TITLE
Update link location, notification method, and namespace check

### DIFF
--- a/DraftCleaner/main.js
+++ b/DraftCleaner/main.js
@@ -111,13 +111,16 @@ if ( isDiff ) return;
 if (mw.config.get('wgNamespaceNumber') < 0) return;
 
 // @ts-ignore
-let menuID = window.draftCleanerPutInToolsMenu ? 'p-tb' : 'p-navigation';
+let menuID = window.draftCleanerPutInToolsMenu ? 'p-cactions' : 'p-navigation';
+
+let titleWithNamespaceAndUnderscores = getArticleName();
+let namespaceNumber = mw.config.get('wgNamespaceNumber');
 
 let running = false;
 
 // Add DraftCleaner to the toolbar
 mw.loader.using(['mediawiki.util'], function () {
-	mw.util.addPortletLink('p-cactions', '#', 'Run DraftCleaner', 'DraftCleanerLink');
+	mw.util.addPortletLink(menuID, '#', 'Run DraftCleaner', 'DraftCleanerLink');
 	$('#DraftCleanerLink').on('click', async function() {
 		// prevent running the script while script is already in progress
 		if (running) return;
@@ -143,10 +146,6 @@ mw.loader.using(['mediawiki.util'], function () {
 		// else display "no changes needed", then reset
 		} else {
 			mw.notify('No changes needed!');
-
-			setTimeout(function (){
-				showClickableButton();
-			}, 2000);
 		}
 });
 });

--- a/DraftCleaner/main.js
+++ b/DraftCleaner/main.js
@@ -37,6 +37,10 @@
 	- if article has headings but no lead, remove first heading
 	- replace unicode bullets with asterisks
 
+Add one of the following to your User:yourName/common.js (at the top) to change the position where DraftCleaner puts its link:
+    window.draftCleanerPutInToolsMenu = true;
+	window.draftCleanerPutInMoreMenu = true;
+
 This page was assembled from 3 files using my publish.php script. I have an offline test suite with around 100 unit tests for the DraftCleaner and StringFilter classes.
 */
 

--- a/DraftCleaner/main.js
+++ b/DraftCleaner/main.js
@@ -153,5 +153,5 @@ mw.loader.using(['mediawiki.util'], function () {
 		} else {
 			mw.notify('No changes needed!');
 		}
-});
+	});
 });

--- a/DraftCleaner/main.js
+++ b/DraftCleaner/main.js
@@ -110,8 +110,14 @@ if ( isDiff ) return;
 // Don't run in virtual namespaces
 if (mw.config.get('wgNamespaceNumber') < 0) return;
 
+let menuID = 'p-navigation';
 // @ts-ignore
-let menuID = window.draftCleanerPutInToolsMenu ? 'p-cactions' : 'p-navigation';
+if ( window.draftCleanerPutInToolsMenu ) {
+	menuID = 'p-tb';
+// @ts-ignore
+} else if ( window.draftCleanerPutInMoreMenu ) {
+	menuID = 'p-cactions';
+}
 
 let titleWithNamespaceAndUnderscores = getArticleName();
 let namespaceNumber = mw.config.get('wgNamespaceNumber');


### PR DESCRIPTION
This PR makes multiple changes:

* Updates the method of adding the start link from appending to the left sidebar, to added to the "More"/"Tools" dropdown menu (using `mw.util.addPortletLink`)
* Improves the notification method, using `mw.notify` instead of a custom display
* Only runs script in non-virtual (Special, Media) namespaces (replaces commented-out check for just mainspace, draftspace, and sandboxes) (closes #117)